### PR TITLE
Pin dependency versions in gemspec

### DIFF
--- a/googledoc_markdown.gemspec
+++ b/googledoc_markdown.gemspec
@@ -18,10 +18,10 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "roadie"
-  spec.add_runtime_dependency "css_parser"
-  spec.add_runtime_dependency "nokogiri"
-  spec.add_runtime_dependency "kramdown"
+  spec.add_runtime_dependency "roadie", "~> 3.1"
+  spec.add_runtime_dependency "css_parser", "~> 1.3"
+  spec.add_runtime_dependency "nokogiri", "~> 1.6"
+  spec.add_runtime_dependency "kramdown", "~> 1.9"
 
   spec.add_development_dependency "bundler", "~> 1.10"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
...so they don't walk around in the future.
